### PR TITLE
Fixes #1 parse error on trig files

### DIFF
--- a/sparql_file/__init__.py
+++ b/sparql_file/__init__.py
@@ -1,4 +1,4 @@
-from rdflib import Graph
+from rdflib import ConjunctiveGraph
 from rdflib_endpoint import SparqlEndpoint
 
 DEFAULT_EXAMPLE_QUERY = "select * { ?s ?p ?o } limit 10"
@@ -9,13 +9,13 @@ def sparql_file(
     example_query: str | None = None,
     graph_format: str | None = None,
 ):
-    g = Graph()
+    g = ConjunctiveGraph()
 
     if example_query is None:
         example_query = DEFAULT_EXAMPLE_QUERY
 
     with open(graph_file, "r") as graph_file_io:
-        g.parse(source=graph_file_io, format=None)
+        g.parse(source=graph_file_io, format=graph_format)
 
     # Return the SPARQL endpoint based on the RDFLib Graph
     return SparqlEndpoint(

--- a/sparql_file/__init__.py
+++ b/sparql_file/__init__.py
@@ -1,4 +1,4 @@
-from rdflib import ConjunctiveGraph
+from rdflib import Dataset as Graph
 from rdflib_endpoint import SparqlEndpoint
 
 DEFAULT_EXAMPLE_QUERY = "select * { ?s ?p ?o } limit 10"
@@ -9,7 +9,7 @@ def sparql_file(
     example_query: str | None = None,
     graph_format: str | None = None,
 ):
-    g = ConjunctiveGraph()
+    g = Graph()
 
     if example_query is None:
         example_query = DEFAULT_EXAMPLE_QUERY

--- a/sparql_file/__init__.py
+++ b/sparql_file/__init__.py
@@ -1,4 +1,4 @@
-from rdflib import Dataset as Graph
+from rdflib import Dataset
 from rdflib_endpoint import SparqlEndpoint
 
 DEFAULT_EXAMPLE_QUERY = "select * { ?s ?p ?o } limit 10"
@@ -9,16 +9,16 @@ def sparql_file(
     example_query: str | None = None,
     graph_format: str | None = None,
 ):
-    g = Graph()
+    ds = Dataset()
 
     if example_query is None:
         example_query = DEFAULT_EXAMPLE_QUERY
 
     with open(graph_file, "r") as graph_file_io:
-        g.parse(source=graph_file_io, format=graph_format)
+        ds.parse(source=graph_file_io, format=graph_format)
 
     # Return the SPARQL endpoint based on the RDFLib Graph
     return SparqlEndpoint(
-        graph=g,
+        graph=ds,
         example_query=example_query,
     )

--- a/sparql_file/cli.py
+++ b/sparql_file/cli.py
@@ -19,7 +19,7 @@ def cli(
     If you want to bind to every address on the IPv4 and IPv6 stack set --host ''
     (cf. https://chaos.social/@white_gecko/114184354432052312)
     """
-    endpoint = sparql_file(graph_file, example_query)
+    endpoint = sparql_file(graph_file, example_query, graph_format)
     uvicorn.run(endpoint, host=host, port=port)
 
 

--- a/sparql_file/env.py
+++ b/sparql_file/env.py
@@ -4,5 +4,6 @@ from . import sparql_file
 
 GRAPH_FILE = os.getenv("GRAPH_FILE", "graph.ttl")
 EXAMPLE_QUERY = os.getenv("EXAMPLE_QUERY")
+GRAPH_FORMAT = os.getenv("GRAPH_FORMAT")
 
-app = sparql_file(GRAPH_FILE, EXAMPLE_QUERY)
+app = sparql_file(GRAPH_FILE, EXAMPLE_QUERY, GRAPH_FORMAT)

--- a/tests/data/example_dataset.trig
+++ b/tests/data/example_dataset.trig
@@ -1,0 +1,105 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix fam: <https://vocab.example.org/family#> .
+@prefix sim: <https://simpsons.example.org/> .
+
+sim:TheSimpsons {
+
+    #The Simpson
+    sim:TheSimpsons rdf:type fam:Family ;
+                    fam:hasFamilyMember sim:Homer ,
+                                        sim:Marge ,
+                                        sim:Bart ,
+                                        sim:Lisa ,
+                                        sim:Maggie .
+
+    #Homer
+    sim:Homer rdf:type foaf:Person .
+    sim:Homer foaf:name "Homer Simpson" .
+    sim:Homer foaf:age "36"^^xsd:int .
+
+    #Marge
+    sim:Marge rdf:type foaf:Person ;
+            foaf:name "Marge Simpson" ;
+            foaf:age "34"^^xsd:int .
+
+    #Bart
+    sim:Bart rdf:type foaf:Person ;
+            foaf:name "Bart Simpson" ;
+            foaf:age "10"^^xsd:int .
+
+    #Lisa
+    sim:Lisa rdf:type foaf:Person ;
+            foaf:name "Lisa Simpson" ;
+            foaf:age "8"^^xsd:int .
+
+    #Maggie
+    sim:Maggie rdf:type foaf:Person ;
+            foaf:name "Maggie Simpson" ;
+            foaf:age "1"^^xsd:int .
+}
+
+sim:Relatives {
+    #Grandparents
+    sim:Abraham rdf:type foaf:Person ;
+        foaf:name "Abraham Simpson".
+    sim:Mona rdf:type foaf:Person .
+
+    #Aunts and Uncles
+    sim:Patty rdf:type foaf:Person .
+    sim:Selma rdf:type foaf:Person .
+    sim:Herb rdf:type foaf:Person .
+
+    sim:Patty fam:hasSister sim:Selma .
+    sim:Selma fam:hasSister sim:Patty .
+
+}
+
+sim:OtherPeople {
+    sim:Moe rdf:type foaf:Person ;
+        foaf:name "Moe Szyslak";
+        foaf:age "50".
+}
+
+#Family relationships
+sim:Homer fam:hasSpouse sim:Marge .
+sim:Marge fam:hasSpouse sim:Homer .
+
+sim:Bart fam:hasFather sim:Homer ;
+         fam:hasMother sim:Marge ;
+         fam:hasSister sim:Lisa ;
+         fam:hasSister sim:Maggie .
+
+sim:Lisa fam:hasFather sim:Homer ;
+         fam:hasMother sim:Marge ;
+         fam:hasBrother sim:Bart ;
+         fam:hasSister sim:Maggie .
+
+sim:Maggie fam:hasFather sim:Homer ;
+           fam:hasMother sim:Marge ;
+           fam:hasBrother sim:Bart ;
+           fam:hasSister sim:Lisa .
+
+#Maggies Grandparents
+sim:Maggie fam:hasParent [
+    fam:hasFather sim:Abraham
+] .
+
+sim:Maggie fam:hasParent [
+    fam:hasMother sim:Mona
+] .
+
+#Lisas Aunts and Uncles
+sim:Lisa fam:hasParent [
+    fam:hasSister sim:Selma ;
+    fam:hasSister sim:Patty
+] .
+
+sim:Lisa fam:hasParent [
+    fam:hasBrother sim:Herb
+] .
+
+#Marge father in law
+sim:Homer fam:hasFather sim:Abraham .

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,3 +13,9 @@ def test_api_with_turtle_graph_specify_format(tmp_path):
     p = tmp_path / "graph_file.ttl"
     copy_file(simpsons.graph_file, p)
     sparql_file(p, graph_format="turtle")
+
+
+def test_api_with_trig_graph_specify_format(tmp_path):
+    p = tmp_path / "dataset.trig"
+    copy_file("tests/data/example_dataset.trig", p)
+    sparql_file(p, graph_format="trig")


### PR DESCRIPTION
Fixes #1 

Fix parameter graph_format not psssed to graph object Fix parameter graph_format not passed to endpoint

The graph format parameter was not passed to the endpoint, resulting in always passing None

Fix graph structure unfit for multiple graphs

The default rdflib.Graph is not able to serve files that have multiple named graphs defined.

fixed by changing to ConjunctiveGraph